### PR TITLE
Add support for different configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 .DS_Store
+.idea

--- a/lib/global_call.rb
+++ b/lib/global_call.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Rk
+  # Anonymous module for including +rk+ to global namespace (class Object).
+  class GlobalCall < Module
+    def initialize(name:, rk_instance:)
+      rk_name = if name.to_s.empty?
+        "rk"
+      else
+        "#{name}_rk"
+      end
+
+      $_rk ||= {}
+      $_rk[rk_name] = rk_instance
+
+      super() do
+        define_method rk_name do |*elements|
+          if elements.empty?
+            $_rk[rk_name]
+          else
+            $_rk[rk_name].rk(elements)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/global_call.rb
+++ b/lib/global_call.rb
@@ -3,11 +3,11 @@
 module Rk
   # Anonymous module for including +rk+ to global namespace (class Object).
   class GlobalCall < Module
-    def initialize(name:, rk_instance:)
-      rk_name = if name.to_s.empty?
+    def initialize(rk_instance)
+      rk_name = if rk_instance.rk_name.to_s.empty?
         "rk"
       else
-        "#{name}_rk"
+        "#{rk_instance.rk_name}_rk"
       end
 
       $_rk ||= {}

--- a/lib/rk.rb
+++ b/lib/rk.rb
@@ -9,15 +9,16 @@ module Rk
   #  * <tt>block</tt> - : optional for setting configurations for details see Rk#initialize
   def self.configure(name = nil)
     instance = Rk.new
+    instance.rk_name = name
     yield(instance) if block_given?
 
-    Object.include(GlobalCall.new(name: name, rk_instance: instance))
+    Object.include(GlobalCall.new(instance))
   end
 
   # Build Redis keys of several elements.
   #   rk("user", 10) => "user:10"
   class Rk
-    attr_accessor :separator, :prefix, :suffix, :keys
+    attr_accessor :separator, :prefix, :suffix, :keys, :rk_name
 
     # Set defaults
     # * <tt>separator</tt> - :
@@ -79,5 +80,5 @@ end # module Rk
 
 # Create a default rk to use it without configuring anything
 # We could use +extend Rk+ to extend only +main+, but we would have to +include Rk+ in
-#any class, hence we include Rk to the global object
-Object.include(Rk::GlobalCall.new(name: nil, rk_instance: Rk::Rk.new))
+# any class, hence we include Rk to the global object
+Object.include(Rk::GlobalCall.new(Rk::Rk.new))

--- a/rk.gemspec
+++ b/rk.gemspec
@@ -1,12 +1,13 @@
 Gem::Specification.new do |g|
   g.name = "rk"
   g.version = "1.1.0"
-  g.date = "2016-12-21"
   g.summary = "Redis key builder"
   g.description = "Ruby helper to generate keys for Redis"
   g.authors = ["Oliver Mensinger"]
   g.email = "oliver.mensinger@gmail.com"
-  g.files = ["lib/rk.rb"]
+  g.files = %w[lib/global_call.rb lib/rk.rb]
   g.homepage = "https://github.com/omensinger/rk"
   g.license = "MIT"
+
+  g.add_development_dependency "minitest"
 end

--- a/test/test_rk.rb
+++ b/test/test_rk.rb
@@ -18,9 +18,11 @@ class TestRk < Minitest::Test
   let(:keys) { { user: "user", "statistics" => "stats", "session" => :sess } }
 
   def setup
-    rk.separator = ":"
-    rk.prefix = ""
-    rk.suffix = ""
+    Rk.configure do |config|
+      config.separator = ":"
+      config.prefix = ""
+      config.suffix = ""
+    end
   end
 
   def test_simple_key
@@ -60,7 +62,7 @@ class TestRk < Minitest::Test
   end
 
   def test_use_undefined_key_element
-    assert_raises RuntimeError do
+    assert_raises NoMethodError do
       rk.something
     end
   end
@@ -86,4 +88,32 @@ class TestRk < Minitest::Test
     assert_equal keys_as_strings, rk.keys
   end
 
+  def test_can_access_config_attributes
+    Rk.configure("test") do |config|
+      config.separator = ":"
+      config.prefix = "pre"
+      config.suffix = "suf"
+    end
+
+    assert_equal ":", test_rk.separator
+    assert_equal "pre", test_rk.prefix
+    assert_equal "suf", test_rk.suffix
+  end
+
+  def test_allow_second_setting
+    Rk.configure("foo") do |config|
+      config.separator = "-"
+    end
+
+    assert_equal "-", foo_rk.separator
+    assert_equal ":", rk.separator
+  end
+
+  def test_named_rk_creates_key
+    Rk.configure("foo") do |config|
+      config.prefix = "foo"
+      config.separator = "-"
+    end
+    assert_equal "foo-bar", foo_rk("bar")
+  end
 end

--- a/test/test_rk.rb
+++ b/test/test_rk.rb
@@ -98,6 +98,7 @@ class TestRk < Minitest::Test
     assert_equal ":", test_rk.separator
     assert_equal "pre", test_rk.prefix
     assert_equal "suf", test_rk.suffix
+    assert_equal "test", test_rk.rk_name
   end
 
   def test_allow_second_setting


### PR DESCRIPTION
Add `Rk.configure` which accepts a name that will create `name_rk`. You can create multiple rk configurations with that if you need the keys in different formats.

Remove date from gemspec since it gets automatically added when building the gem

Add development dependencies to gemspec for dev setup via: `gem install --development rk`

Fix bug that it was not possible to ask rk for configurations options (separator, prefix & suffix)

------------

The app i am currently working on is connected to two different redis databases. Unfortunately both use a different format for the keys. I would like to use this gem, since i enjoyed using it in the past. But due to the global configuration it wasn't possible.

With my changes it is now possible to create different named configurations:
```ruby
Rk.configre("foo") do |config|
  config.separator = ":"
end

Rk.configure("bar") do |config|
  config.separator = "-"
end

foo_rk("test", 1)
=> test:1

bar_rk("test", 1)
=> test-1
```

I tried not to create breaking changes. It should be totally fine to use rk just as before. The only change that may break something is that calling rk with a non existing key now returns a NoMethodError instead of a runtime error.

Let me know what you think about this. If you like it, i can change the README too.